### PR TITLE
Remove token name match check

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -147,10 +147,6 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 			return fmt.Errorf("Token expired")
 		}
 
-		if !shared.ValueInSlice(record.Name, req.Certificate.DNSNames) {
-			return fmt.Errorf("Joining server certificate SAN does not contain join token name")
-		}
-
 		_, err = cluster.CreateCoreClusterMember(ctx, tx, dbClusterMember)
 		if err != nil {
 			return err


### PR DESCRIPTION
Removing the token name match check on join as a workaround to unblock CAPI work while working towards a proper solution in k8s-snap. 