### PR TITLE
Change project name detection on prepare statements

### DIFF
--- a/cluster/stmt.go
+++ b/cluster/stmt.go
@@ -47,9 +47,11 @@ func RegisterStmt(sql string) int {
 func PrepareStmts(db *sql.DB, project string, skipErrors bool) error {
 	logger.Infof("Preparing statements for Go project %q", project)
 
+	mclCaller := GetCallerProject()
+
 	// Also prepare statements from microcluster if we are in a different project.
-	projects := []string{"microcluster"}
-	if project != "microcluster" {
+	projects := []string{mclCaller}
+	if project != mclCaller {
 		projects = append(projects, project)
 	}
 


### PR DESCRIPTION
Any changes to the folder/repository causes an issue with statement registrations, to address this the hard coded name is updated to use the caller project. 